### PR TITLE
Enabled generating `rewire` stub for named constant exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,13 +198,21 @@ require("@babel/core").transform("code", {
 });
 ```
 
+## Limitations
+Named constant exports cannot be rewired, because the plugin relies on variables being assign-able in order to work.
+E.g. rewiring the following export throws an exception:
+
+```js
+export const foo = 'bar';
+```
+
+See [unsafeConst](https://github.com/asapach/babel-plugin-rewire-exports#unsafeconst) option to enable *potentially unsafe* rewiring constant exports.
+
 ## Options
 
 ### `unsafeConst`
 `boolean`, defaults to `false`.
-
-Constants cannot be rewired, because the plugin relies on variables being assign-able in order to work.
-However setting `unsafeConst: true` will convert `export const foo = 'bar'` to `export let foo = 'bar'`.
+Setting `unsafeConst: true` will convert `export const foo = 'bar'` to `export let foo = 'bar'`.
 This will allow to treat named constant exports as a regular variables.
 This is *potentially unsafe* if your code relies on constants being read-only.
 

--- a/test/fixtures/transform-named-export-constant/expected.js
+++ b/test/fixtures/transform-named-export-constant/expected.js
@@ -6,6 +6,9 @@ var _baz2 = _baz;
 export function rewire$baz($stub) {
   _baz = $stub;
 }
+export function rewire$foo() {
+  throw new Error('Named constant exports cannot be rewired, see https://github.com/asapach/babel-plugin-rewire-exports#limitations');
+}
 export function restore() {
   _baz = _baz2;
 }


### PR DESCRIPTION
At the moment named constant exports are just ignored:
```js
export const foo = 'bar';
```
No rewire stubs are added for this export, so if you try import `rewire$foo` in your test, you get `import is not defined` error that is unexpected for plugin consumers.

The PR adds rewire stubs for named constant export . The  generated stub function point out to the existing limitations.