### PR TITLE
Enable rewiring for named constant exports

### DIFF
--- a/test/fixtures/transform-named-export-constant/actual.js
+++ b/test/fixtures/transform-named-export-constant/actual.js
@@ -1,4 +1,4 @@
-export const foo = 'bar';
+export const foo = 'bar', baz = 'qux';
 
-const baz = false;
-export { baz };
+const whatsit = false;
+export { whatsit };

--- a/test/fixtures/transform-named-export-constant/expected.js
+++ b/test/fixtures/transform-named-export-constant/expected.js
@@ -1,11 +1,25 @@
-export const foo = 'bar';
-const baz = false;
+const foo = 'bar',
+      baz = 'qux';
+var _foo = foo;
 var _baz = baz;
-export { _baz as baz };
-var _baz2 = _baz;
+export { _foo as foo, _baz as baz };
+const whatsit = false;
+var _whatsit = whatsit;
+export { _whatsit as whatsit };
+var _whatsit2 = _whatsit,
+    _foo2 = _foo,
+    _baz2 = _baz;
+export function rewire$whatsit($stub) {
+  _whatsit = $stub;
+}
+export function rewire$foo($stub) {
+  _foo = $stub;
+}
 export function rewire$baz($stub) {
   _baz = $stub;
 }
 export function restore() {
+  _whatsit = _whatsit2;
+  _foo = _foo2;
   _baz = _baz2;
 }

--- a/test/fixtures/transform-named-export-destructuring/actual.js
+++ b/test/fixtures/transform-named-export-destructuring/actual.js
@@ -1,2 +1,5 @@
-export var {foo, bar = false, baz} = qux;
+export var {foo, bar = false} = qux;
 export var [ham = 1, ...eggs] = bacon;
+
+export const {quux, quuz = false} = fred;
+export const [corge = 1, ...grault] = garply;

--- a/test/fixtures/transform-named-export-destructuring/expected.js
+++ b/test/fixtures/transform-named-export-destructuring/expected.js
@@ -1,22 +1,32 @@
 export var {
   foo,
-  bar = false,
-  baz
+  bar = false
 } = qux;
 export var [ham = 1, ...eggs] = bacon;
+const {
+  quux,
+  quuz = false
+} = fred;
+var _quux = quux;
+var _quuz = quuz;
+export { _quux as quux, _quuz as quuz };
+const [corge = 1, ...grault] = garply;
+var _corge = corge;
+var _grault = grault;
+export { _corge as corge, _grault as grault };
 var _foo = foo,
     _bar = bar,
-    _baz = baz,
     _ham = ham,
-    _eggs = eggs;
+    _eggs = eggs,
+    _quux2 = _quux,
+    _quuz2 = _quuz,
+    _corge2 = _corge,
+    _grault2 = _grault;
 export function rewire$foo($stub) {
   foo = $stub;
 }
 export function rewire$bar($stub) {
   bar = $stub;
-}
-export function rewire$baz($stub) {
-  baz = $stub;
 }
 export function rewire$ham($stub) {
   ham = $stub;
@@ -24,10 +34,25 @@ export function rewire$ham($stub) {
 export function rewire$eggs($stub) {
   eggs = $stub;
 }
+export function rewire$quux($stub) {
+  _quux = $stub;
+}
+export function rewire$quuz($stub) {
+  _quuz = $stub;
+}
+export function rewire$corge($stub) {
+  _corge = $stub;
+}
+export function rewire$grault($stub) {
+  _grault = $stub;
+}
 export function restore() {
   foo = _foo;
   bar = _bar;
-  baz = _baz;
   ham = _ham;
   eggs = _eggs;
+  _quux = _quux2;
+  _quuz = _quuz2;
+  _corge = _corge2;
+  _grault = _grault2;
 }

--- a/test/issues/13/actual.js
+++ b/test/issues/13/actual.js
@@ -2,9 +2,14 @@ export function spam() {
   return {
     eggs() {
       eggs();
+    },
+    foo(){
+      console.log(foo);
     }
   };
 }
 
 export function eggs() {
 }
+
+export const foo = 1;

--- a/test/issues/13/expected.js
+++ b/test/issues/13/expected.js
@@ -5,6 +5,9 @@ function _spam() {
   return {
     eggs: function eggs() {
       _eggs2();
+    },
+    foo: function foo() {
+      console.log(_foo);
     }
   };
 }
@@ -14,13 +17,20 @@ export { spam };
 function _eggs() {}
 
 export { _eggs2 as eggs };
+var _foo = 1;
+export { _foo as foo };
+var _foo2 = _foo;
 export function rewire$spam($stub) {
   spam = $stub;
 }
 export function rewire$eggs($stub) {
   _eggs2 = $stub;
 }
+export function rewire$foo($stub) {
+  _foo = $stub;
+}
 export function restore() {
   spam = _spam;
   _eggs2 = _eggs;
+  _foo = _foo2;
 }


### PR DESCRIPTION
At the moment named constant exports are just ignored:
```js
export const foo = 'bar';
```
No rewire stubs are added for this export, so if you try import `rewire$foo` in your test, you get `import is not defined` error that is unexpected for plugin consumers.

The PR enables rewiring for named constant export.

**In**
```js
export const foo = 'bar';
```
**Out**
```js
const foo = 'bar';
var _foo = foo;
export { _foo as foo };
var _foo2 = _foo;
export function rewire$foo($stub) {
  _foo = $stub;
}
export function restore() {
  _foo = _foo2;
}
```