### PR TITLE
Eliminate redundant variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,11 +79,16 @@ export default function ({types: t}) {
             path.unshiftContainer('body', [t.variableDeclaration('var', hoisted)]);
           }
 
-          // generate temp variables to capture original values
+          // generate temp variables if it's required to capture original values
           const tempVars = [];
           exports.filter(e => !e.original).forEach(e => {
-            const temp = e.original = path.scope.generateUidIdentifierBasedOnNode(e.exported);
-            tempVars.push(t.variableDeclarator(temp, e.local));
+            const {exported, local} = e;
+            if (path.scope.hasBinding(exported.name) && exported.name !== local.name) {
+              e.original = exported;
+            } else {
+              const temp = e.original = path.scope.generateUidIdentifierBasedOnNode(exported);
+              tempVars.push(t.variableDeclarator(temp, local));
+            }
           });
 
           // generate new IDs to keep sourcemaps clean

--- a/test/fixtures/transform-default-import-export/output.js
+++ b/test/fixtures/transform-default-import-export/output.js
@@ -4,8 +4,7 @@ var _foo = foo;
 export { _foo as foo };
 var _default = foo;
 export { _default as default };
-var _foo2 = _foo,
-    _default2 = _default;
+var _default2 = _default;
 export function rewire$foo($stub) {
   _foo = $stub;
 }
@@ -13,6 +12,6 @@ export function rewire($stub) {
   _default = $stub;
 }
 export function restore() {
-  _foo = _foo2;
+  _foo = foo;
   _default = _default2;
 }

--- a/test/fixtures/transform-multiple-exports/output.js
+++ b/test/fixtures/transform-multiple-exports/output.js
@@ -23,9 +23,7 @@ var _whatever = whatever;
 export { _whatnot as whatnot, _whatever as whatever };
 var _qux = bar,
     _baz = baz,
-    _whatsit = whatsit,
-    _whatnot2 = _whatnot,
-    _whatever2 = _whatever;
+    _whatsit = whatsit;
 export function rewire($stub) {
   foo = $stub;
 }
@@ -53,6 +51,6 @@ export function restore() {
   bar = _qux;
   baz = _baz;
   whatsit = _whatsit;
-  _whatnot = _whatnot2;
-  _whatever = _whatever2;
+  _whatnot = whatnot;
+  _whatever = whatever;
 }

--- a/test/fixtures/transform-named-export-constant/output.js
+++ b/test/fixtures/transform-named-export-constant/output.js
@@ -6,9 +6,6 @@ export { _foo as foo, _baz as baz };
 const whatsit = false;
 var _whatsit = whatsit;
 export { _whatsit as whatsit };
-var _whatsit2 = _whatsit,
-    _foo2 = _foo,
-    _baz2 = _baz;
 export function rewire$whatsit($stub) {
   _whatsit = $stub;
 }
@@ -19,7 +16,7 @@ export function rewire$baz($stub) {
   _baz = $stub;
 }
 export function restore() {
-  _whatsit = _whatsit2;
-  _foo = _foo2;
-  _baz = _baz2;
+  _whatsit = whatsit;
+  _foo = foo;
+  _baz = baz;
 }

--- a/test/fixtures/transform-named-export-destructuring/output.js
+++ b/test/fixtures/transform-named-export-destructuring/output.js
@@ -17,11 +17,7 @@ export { _corge as corge, _grault as grault };
 var _foo = foo,
     _bar = bar,
     _ham = ham,
-    _eggs = eggs,
-    _quux2 = _quux,
-    _quuz2 = _quuz,
-    _corge2 = _corge,
-    _grault2 = _grault;
+    _eggs = eggs;
 export function rewire$foo($stub) {
   foo = $stub;
 }
@@ -51,8 +47,8 @@ export function restore() {
   bar = _bar;
   ham = _ham;
   eggs = _eggs;
-  _quux = _quux2;
-  _quuz = _quuz2;
-  _corge = _corge2;
-  _grault = _grault2;
+  _quux = quux;
+  _quuz = quuz;
+  _corge = corge;
+  _grault = grault;
 }

--- a/test/fixtures/transform-named-import-export/output.js
+++ b/test/fixtures/transform-named-import-export/output.js
@@ -4,8 +4,7 @@ var _foo = foo;
 export { _foo as foo };
 var _default = foo;
 export { _default as default };
-var _foo2 = _foo,
-    _default2 = _default;
+var _default2 = _default;
 export function rewire$foo($stub) {
   _foo = $stub;
 }
@@ -13,6 +12,6 @@ export function rewire($stub) {
   _default = $stub;
 }
 export function restore() {
-  _foo = _foo2;
+  _foo = foo;
   _default = _default2;
 }

--- a/test/issues/5/output.js
+++ b/test/issues/5/output.js
@@ -11,12 +11,11 @@ var _module = require("./module1");
 
 var _say = _module.say;
 exports.say = _say;
-var _say2 = _say;
 
 function rewire$say($stub) {
   exports.say = _say = $stub;
 }
 
 function restore() {
-  exports.say = _say = _say2;
+  exports.say = _say = _module.say;
 }


### PR DESCRIPTION
The plugin generates redundant variables for some cases, e.g.:

**In**
```js
export const foo = 'bar';
```
**Out**
```js
const foo = 'bar';
var _foo = foo;
export { _foo as foo };
var _foo2 = _foo;
export function rewire$foo($stub) {
  _foo = $stub;
}
export function restore() {
  _foo = _foo2;
}
```

Added `_foo2` variable is redundant here, `_foo` can be restored by using original `foo`:
```diff
const foo = 'bar';
var _foo = foo;
export { _foo as foo };
- var _foo2 = _foo;
export function rewire$foo($stub) {
  _foo = $stub;
}
export function restore() {
-  _foo = _foo2;
+  _foo = foo;
}
```

The PR eliminates redundant variables, it generates variables to capture only if required.